### PR TITLE
Ignore pubspec.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ migrate_working_dir/
 # Flutter/Dart/Pub related
 **/doc/api/
 **/ios/Flutter/.last_build_id
+*.lock
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies


### PR DESCRIPTION
This PR adds '*.lock' to .gitignore to prevent tracking lock files like pubspec.lock.