### PR TITLE
Fix: Display rewatchingList and rereadingList on HomeScreen + JSON cleanup and Esc key support

### DIFF
--- a/assets/languages/de.json
+++ b/assets/languages/de.json
@@ -60,7 +60,6 @@
   "chapter": "Kapitel",
   "settings": "Einstellungen",
   "remote_endpoint": "Remote-Erweiterungen / Lokale Erweiterungen",
-"select_quality" : "Qualität auswählen",
 "local_extensions" : "Lokale Erweiterungen",
 "extension" : "Erweiterung",
 "extensions" : "Erweiterungen",

--- a/assets/languages/en.json
+++ b/assets/languages/en.json
@@ -60,7 +60,6 @@
   "chapter" : "Chapter",
   "settings": "Settings",
   "remote_endpoint" : "Remote extensions / Local extensions",
-  "select_quality" : "Select Quality",
   "local_extensions" : "Local Extensions",
   "extension" : "extension",
   "extensions" : "Extensions",

--- a/assets/languages/es.json
+++ b/assets/languages/es.json
@@ -60,7 +60,6 @@
   "chapter": "Capítulo",
   "settings": "Configuraciones",
   "remote_endpoint": "Extensiones remotas / Extensiones locales",
-"select_quality" : "Seleccionar calidad",
 "local_extensions" : "Extensiones locales",
 "extension" : "extensión",
 "extensions" : "Extensiones",

--- a/assets/languages/fr.json
+++ b/assets/languages/fr.json
@@ -60,7 +60,6 @@
   "chapter": "Chapitre",
   "settings": "Paramètres",
   "remote_endpoint": "Extensions distantes / Extensions locales",
-"select_quality" : "Sélectionner la qualité",
 "local_extensions" : "Extensions locales",
 "extension" : "extension",
 "extensions" : "Extensions",

--- a/assets/languages/it.json
+++ b/assets/languages/it.json
@@ -60,7 +60,6 @@
   "chapter": "Capitolo",
   "settings": "Impostazioni",
   "remote_endpoint": "Estensioni remote / Estensioni locali",
-"select_quality" : "Seleziona qualità",
 "local_extensions" : "Estensioni locali",
 "extension" : "estensione",
 "extensions" : "Estensioni",

--- a/assets/languages/pt.json
+++ b/assets/languages/pt.json
@@ -60,7 +60,6 @@
   "chapter": "Capítulo",
   "settings": "Configurações",
   "remote_endpoint": "Extensões remotas / Extensões locais",
-"select_quality" : "Selecionar qualidade",
 "local_extensions" : "Extensões locais",
 "extension" : "extensão",
 "extensions" : "Extensões",

--- a/assets/languages/ru.json
+++ b/assets/languages/ru.json
@@ -60,7 +60,6 @@
   "chapter": "Глава",
   "settings": "Настройки",
   "remote_endpoint": "Удалённые расширения / Локальные расширения",
-"select_quality" : "Выбрать качество",
 "local_extensions" : "Локальные расширения",
 "extension" : "расширение",
 "extensions" : "Расширения",

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -31,6 +31,8 @@ class _HomeScreenState extends State<HomeScreen> {
   Map<String, Map<String, double>>? userStats;
   int? episodesWatched;
   int? minutesWatched;
+  List<AnimeModel>? rewatchingList;
+  List<MangaModel>? rereadingList;
 
   void attemptLogin() async {
     prefs = PreferencesModel();
@@ -110,8 +112,12 @@ class _HomeScreenState extends State<HomeScreen> {
     String newavatarUrl = await loggedUserModel.getUserAvatarImageUrl();
     List<AnimeModel> newWatchingAnimeList =
         await loggedUserModel.getUserAnimeLists("Watching");
+    List<AnimeModel> newRewatchingAnimeList = 
+      await loggedUserModel.getUserAnimeLists("Rewatching");
     List<MangaModel> newReadingMangaList =
         await loggedUserModel.getUserMangaLists("Reading");
+    List<MangaModel> newRereadingMangaList =
+        await loggedUserModel.getUserMangaLists("Rereading");
     //TODO fix stats
     Map<String, Map<String, double>> newUserStats =
         (loggedUserModel is AnilistUserModel) ? await getUserStatsMaps() : {};
@@ -123,7 +129,9 @@ class _HomeScreenState extends State<HomeScreen> {
     setState(() {
       avatarImageUrl = newavatarUrl;
       watchingList = newWatchingAnimeList;
+      rewatchingList = newRewatchingAnimeList;
       readingList = newReadingMangaList;
+      rereadingList = newRereadingMangaList;
       userStats = newUserStats;
     });
     prefs.saveUser(loggedUserModel);
@@ -134,11 +142,17 @@ class _HomeScreenState extends State<HomeScreen> {
   void updateUserLists() async {
     List<AnimeModel> newWatchingAnimeList =
         await loggedUserModel.getUserAnimeLists("Watching");
+    List<AnimeModel> newRewatchingAnimeList = 
+      await loggedUserModel.getUserAnimeLists("Rewatching");
     List<MangaModel> newReadingMangaList =
         await loggedUserModel.getUserMangaLists("Reading");
+    List<MangaModel> newRereadingMangaList =
+        await loggedUserModel.getUserMangaLists("Rereading");    
     setState(() {
       watchingList = newWatchingAnimeList;
+      rewatchingList = newRewatchingAnimeList;
       readingList = newReadingMangaList;
+      rereadingList = newRereadingMangaList;
     });
   }
 
@@ -445,7 +459,10 @@ class _HomeScreenState extends State<HomeScreen> {
                                 ? AnimeWidgetList(
                                     tag: "home-details-list1",
                                     title: context.tr("continue_watching"),
-                                    animeList: watchingList!,
+                                    animeList: [
+                                        if (rewatchingList != null) ...rewatchingList!,
+                                        ...watchingList!,
+                                    ],
                                     textColor: Colors.white,
                                     loadMore: false,
                                     updateHomeScreenLists: updateUserLists,
@@ -459,7 +476,10 @@ class _HomeScreenState extends State<HomeScreen> {
                                 ? MangaWidgetList(
                                     tag: "home-details-list2",
                                     title: context.tr("continue_reading"),
-                                    mangaList: readingList!,
+                                    mangaList: [
+                                        if (rereadingList != null) ...rereadingList!,
+                                        ...readingList!,
+                                    ],
                                     textColor: Colors.white,
                                     loadMore: false,
                                     updateHomeScreenLists: updateUserLists,

--- a/lib/screens/video_screen.dart
+++ b/lib/screens/video_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:desktop_keep_screen_on/desktop_keep_screen_on.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_acrylic/window.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 import 'package:unyo/dialogs/dialogs.dart';
@@ -148,18 +149,29 @@ class _VideoScreenState extends State<VideoScreen> {
       color: Colors.black,
       child: KeyboardListener(
         focusNode: _screenFocusNode,
-        onKeyEvent: (keyEnvent) {
-          if (keyDelay) {
-            return;
-          }
+        onKeyEvent: (keyEvent) {
+          if (keyDelay) return;
+
           keyDelay = true;
-          Timer(
-            const Duration(milliseconds: 200),
-            () {
-              keyDelay = false;
-            },
-          );
-          _mixedController.mqqtController.onReceivedKeys(keyEnvent.logicalKey);
+          Timer(const Duration(milliseconds: 200), () {
+            keyDelay = false;
+          });
+
+          final key = keyEvent.logicalKey;
+
+          _mixedController.mqqtController.onReceivedKeys(key);
+
+          // ESC key support
+          if (key == LogicalKeyboardKey.escape) {
+            if (fullScreen) {
+              Window.exitFullscreen();
+              fullScreen = false;
+              setState(() {});
+            } else {
+              interactScreen(false);
+              Navigator.pop(context);
+            }
+          }
         },
         child: Center(
           child: Stack(


### PR DESCRIPTION
This PR addresses a few key improvements and fixes:


- ✅ Ensures `rewatchingList` and `rereadingList` are fetched and displayed on the Home Screen. 

- 🧹 Removes duplicate `'select_quality'` key from the localization JSON.

- ⌨️ Adds support for exiting the video screen using the `Esc` key.


#### Detailed Changes:

- Assigned `rewatchingList` and `rereadingList` in both `setUserInfo` and `updateUserLists`

- Displayed those lists in "Continue Watching" and "Continue Reading" sections

- Cleaned up the localization file by removing duplicate keys

- Handled `RawKeyDownEvent` to listen for Esc press and pop the video screen