### PR TITLE
feat(discord-rpc): add GitHub and Download App buttons to Rich Presence; respect discord_rpc setting with conditional autoRetry & proper cleanup;

### DIFF
--- a/lib/models/preferences_model.dart
+++ b/lib/models/preferences_model.dart
@@ -97,7 +97,8 @@ class PreferencesModel {
   }
 
   String? getString(String key) {
-    return box.get(key) as String?;
+    dynamic value = box.get(key);
+    return value?.toString(); // Convert to String
   }
 
   void setString(String key, String value) {

--- a/lib/models/preferences_model.dart
+++ b/lib/models/preferences_model.dart
@@ -97,8 +97,7 @@ class PreferencesModel {
   }
 
   String? getString(String key) {
-    dynamic value = box.get(key);
-    return value?.toString(); // Convert to String
+    return box.get(key) as String?;
   }
 
   void setString(String key, String value) {

--- a/lib/screens/anime_details_screen.dart
+++ b/lib/screens/anime_details_screen.dart
@@ -80,7 +80,7 @@ class _AnimeDetailsScreenState extends State<AnimeDetailsScreen> {
     final List<String> sourcesNames = animeSources.values.map((a) => a.getSourceName()).toList();
     final String? savedSource = prefs.getString(_defaultAnimeSourceKey);
     if (savedSource != null && sourcesNames.contains(savedSource)) {
-      logger.i("Found saved previously saved source: $savedSource");
+      logger.i("Found previously saved source: $savedSource");
       return sourcesNames.indexOf(savedSource);
     }
     return 0;

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -72,9 +72,11 @@ class _HomeScreenState extends State<HomeScreen> {
 
   void setDiscordRPC() async{
     final bool discordEnabled = prefs.getBool("discord_rpc") ?? false;
-    if (discordEnabled) {
-      await discord.initDiscordRPC();
+    if (!discordEnabled) {
+       await discord.cleanup();
+       return;
     }
+    await discord.initDiscordRPC(autoRetry: discordEnabled);
   }
 
   void goToLogin() {

--- a/lib/screens/manga_details_screen.dart
+++ b/lib/screens/manga_details_screen.dart
@@ -78,11 +78,10 @@ class _MangaDetailsScreenState extends State<MangaDetailsScreen> {
   }
 
   int getSavedSource() {
-    final List<String> sourcesNames = mangaSources.values.map((a) =>
-        a.getSourceName()).toList();
+    final List<String> sourcesNames = mangaSources.values.map((a) => a.getSourceName()).toList();
     final String? savedSource = prefs.getString(_defaultMangaSourceKey);
     if (savedSource != null && sourcesNames.contains(savedSource)) {
-      logger.i("Found saved previously saved source: $savedSource");
+      logger.i("Found previously saved source: $savedSource");
       return sourcesNames.indexOf(savedSource);
     }
     return 0;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -128,7 +128,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       prefs.setBool("discord_rpc", newValue);
                     });
                     if (newValue) {
-                      await discord.initDiscordRPC();
+                      await discord.initDiscordRPC(autoRetry: true);
                     } else {
                       await discord.cleanup();
                     }

--- a/lib/util/discord_rpc.dart
+++ b/lib/util/discord_rpc.dart
@@ -75,6 +75,16 @@ class DiscordRPC {
           start: initTime.millisecondsSinceEpoch,
           end: null,
         ),
+        buttons: [
+          const RPCButton(
+            label: "GitHub Repository",
+            url: "https://github.com/K3vinb5/Unyo",
+          ),
+          const RPCButton(
+            label: "Download App",
+            url: "https://github.com/K3vinb5/Unyo/releases",
+          ),
+        ],
       ),
     );
   }
@@ -95,6 +105,16 @@ class DiscordRPC {
           start: initTime.millisecondsSinceEpoch,
           end: null,
         ),
+        buttons: [
+          const RPCButton(
+            label: "GitHub Repository",
+            url: "https://github.com/K3vinb5/Unyo",
+          ),
+          const RPCButton(
+            label: "Download App",
+            url: "https://github.com/K3vinb5/Unyo/releases",
+          ),
+        ],
       ),
     );
   }
@@ -115,6 +135,16 @@ class DiscordRPC {
           start: initTime.millisecondsSinceEpoch,
           end: null,
         ),
+        buttons: [
+          const RPCButton(
+            label: "GitHub Repository",
+            url: "https://github.com/K3vinb5/Unyo",
+          ),
+          const RPCButton(
+            label: "Download App",
+            url: "https://github.com/K3vinb5/Unyo/releases",
+          ),
+        ],
       ),
     );
   }
@@ -145,6 +175,16 @@ class DiscordRPC {
           start: initTime.millisecondsSinceEpoch,
           end: null,
         ),
+        buttons: [
+          const RPCButton(
+            label: "GitHub Repository",
+            url: "https://github.com/K3vinb5/Unyo",
+          ),
+          const RPCButton(
+            label: "Download App",
+            url: "https://github.com/K3vinb5/Unyo/releases",
+          ),
+        ],
       ),
     );
   }
@@ -165,6 +205,16 @@ class DiscordRPC {
           start: initTime.millisecondsSinceEpoch,
           end: null,
         ),
+        buttons: [
+          const RPCButton(
+            label: "GitHub Repository",
+            url: "https://github.com/K3vinb5/Unyo",
+          ),
+          const RPCButton(
+            label: "Download App",
+            url: "https://github.com/K3vinb5/Unyo/releases",
+          ),
+        ],
       ),
     );
   }

--- a/lib/util/discord_rpc.dart
+++ b/lib/util/discord_rpc.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter_discord_rpc/flutter_discord_rpc.dart';
 import 'package:unyo/models/models.dart';
 import 'package:unyo/util/utils.dart';
@@ -7,9 +8,10 @@ class DiscordRPC {
   bool _initialized = false;
   DateTime initTime = DateTime.now();
   bool discordConnected = false;
+  StreamSubscription<bool>? _connSub;
 
   /// Initialize Discord RPC once
-  Future<void> initDiscordRPC() async {
+  Future<void> initDiscordRPC({bool autoRetry = false}) async {
     try {
       // only call initialize() once per process
       if (!_initialized) {
@@ -24,7 +26,7 @@ class DiscordRPC {
       }
 
       // otherwise, connect and then set the initial activity
-      await FlutterDiscordRPC.instance.connect(autoRetry: true);
+      await FlutterDiscordRPC.instance.connect(autoRetry: autoRetry);
       discordConnected = FlutterDiscordRPC.instance.isConnected;
 
       logger.i('Discord RPC connected: $discordConnected');
@@ -36,19 +38,19 @@ class DiscordRPC {
       }
 
       // listen for reconnects (e.g. if the user restarts Discord)
-      FlutterDiscordRPC.instance.isConnectedStream.listen((connected) {
-        discordConnected = connected;
-        logger.i('Discord RPC connection status: $connected');
-        if (connected) {
-          setPageActivity('Home Screen');
-        }
-      });
+        _connSub = FlutterDiscordRPC.instance.isConnectedStream.listen((connected) {
+          discordConnected = connected;
+          logger.i('Discord RPC connection status: $connected');
+          if (connected) setPageActivity('Home Screen');
+        });
     } catch (e) {
       logger.e('Discord RPC initialization failed: $e');
     }
   }
 
   Future<void> cleanup() async {
+    await _connSub?.cancel();
+    _connSub = null;
     if (!discordConnected) return;
     try {
       await FlutterDiscordRPC.instance.clearActivity();


### PR DESCRIPTION
**What was changed**

* **discord_rpc.dart**

  * Added `autoRetry` parameter to `initDiscordRPC({bool autoRetry})` and pass it into `connect(autoRetry:)`.
  * Subscribed to `isConnectedStream` with a `StreamSubscription<bool>? _connSub` so we can cancel it later.
  * Imported `dart:async` for `StreamSubscription`.
  * In `cleanup()`, cancel `_connSub` and disconnect/clear activity so no retries or listeners remain when disabled.
  * Added two `RPCButton`s (“GitHub Repository” and “Download App”) to each `setActivity(...)` call.
 
* **home_screen.dart**

  * In `setDiscordRPC()`, forward the `prefs.getBool("discord_rpc")` value into `initDiscordRPC(autoRetry:)`, and call `cleanup()` when the setting is off.
  * After returning from Settings, re-invoke `setDiscordRPC()` so toggling the switch immediately applies.
  
* **settings_screen.dart**

  * In the Discord RPC toggle’s `onPressed`, call `initDiscordRPC(autoRetry: true)` when enabled and `cleanup()` when disabled.
  
* **Others**
  * And some typos 