### PR TITLE
Display genres for both Anime and Manga & add full-screen reading mode for Manga

### DIFF
--- a/lib/models/adapters/anime_model_adapter.dart
+++ b/lib/models/adapters/anime_model_adapter.dart
@@ -26,6 +26,7 @@ class AnimeModelAdapter extends TypeAdapter<AnimeModel> {
       episodes: fields[14],
       currentEpisode: fields[15],
       duration: fields[16],
+      genres: fields[17],
     );
   }
 
@@ -69,5 +70,7 @@ class AnimeModelAdapter extends TypeAdapter<AnimeModel> {
     writer.write(obj.currentEpisode);
     writer.writeByte(16);
     writer.write(obj.duration);
+    writer.writeByte(17);
+    writer.write(obj.genres ?? []);
   }
 }

--- a/lib/models/adapters/manga_model_adapter.dart
+++ b/lib/models/adapters/manga_model_adapter.dart
@@ -26,6 +26,7 @@ class MangaModelAdapter extends TypeAdapter<MangaModel> {
       chapters: fields[14],
       currentEpisode: fields[15],
       duration: fields[16],
+      genres: fields[17],
     );
   }
 
@@ -69,5 +70,7 @@ class MangaModelAdapter extends TypeAdapter<MangaModel> {
     writer.write(obj.currentEpisode);
     writer.writeByte(16);
     writer.write(obj.duration);
+    writer.writeByte(17);
+    writer.write(obj.genres ?? []);
   }
 }

--- a/lib/models/anime_model.dart
+++ b/lib/models/anime_model.dart
@@ -18,6 +18,7 @@ class AnimeModel {
     required this.duration,
     required this.description,
     required this.format,
+    required this.genres,
     this.currentEpisode,
   });
 
@@ -39,6 +40,7 @@ class AnimeModel {
   int? currentEpisode;
   int? duration;
 
+  List<String>? genres;
   factory AnimeModel.fromJson(Map<String, dynamic> json) {
     return AnimeModel(
       id: json['id'],
@@ -60,6 +62,7 @@ class AnimeModel {
       episodes: json['episodes'],
       currentEpisode: json['currentEpisode'],
       duration: json['duration'],
+      genres: List<String>.from(json['genres'] ?? []),
     );
   }
 
@@ -82,6 +85,7 @@ class AnimeModel {
       'episodes': episodes,
       'currentEpisode': currentEpisode,
       'duration': duration,
+      'genres': genres,
     };
   }
 

--- a/lib/models/manga_model.dart
+++ b/lib/models/manga_model.dart
@@ -16,6 +16,7 @@ class MangaModel {
     required this.averageScore,
     required this.chapters,
     required this.duration,
+    required this.genres,
     required this.description,
     required this.format,
     this.currentEpisode,
@@ -34,6 +35,7 @@ class MangaModel {
   String? status;
   String? description;
   String? format;
+  List<String>? genres;
   int? averageScore;
   int? chapters;
   int? currentEpisode;
@@ -60,6 +62,7 @@ class MangaModel {
       chapters: json['chapters'],
       currentEpisode: json['currentEpisode'],
       duration: json['duration'],
+      genres: List<String>.from(json['genres'] ?? []),
     );
   }
 
@@ -82,6 +85,7 @@ class MangaModel {
       'chapters': chapters,
       'currentEpisode': currentEpisode,
       'duration': duration,
+      'genres': genres,
     };
   }
 

--- a/lib/screens/manga_screen.dart
+++ b/lib/screens/manga_screen.dart
@@ -187,6 +187,7 @@ class _MangaScreenState extends State<MangaScreen> {
                                         episodes: mangaModel.chapters,
                                         duration: mangaModel.duration,
                                         description: mangaModel.description,
+                                        genres: mangaModel.genres,
                                         format: mangaModel.format),
                                     width: totalWidth,
                                     height: totalHeight * 0.35,

--- a/lib/screens/reading_screen.dart
+++ b/lib/screens/reading_screen.dart
@@ -41,6 +41,7 @@ class _ReadingScreenState extends State<ReadingScreen> {
   int currentFittingOption = 0;
   int currentInverseModeOption = 0;
   int currentOrientationOption = 0;
+  bool isFullscreen = false;
 
   @override
   void initState() {
@@ -97,6 +98,12 @@ class _ReadingScreenState extends State<ReadingScreen> {
     });
   }
 
+  void fullscreenToggle() {
+    setState(() {
+      isFullscreen = !isFullscreen;
+    });
+  }
+
   void onReceivedKeys(LogicalKeyboardKey logicalKey) {
     bool isLeftToRight = currentOrientationOption == 0;
     switch (logicalKey) {
@@ -129,11 +136,20 @@ class _ReadingScreenState extends State<ReadingScreen> {
       case LogicalKeyboardKey.keyJ:
         goBackPage();
         break;
+      case LogicalKeyboardKey.keyF:
+        fullscreenToggle();
+        break;
       case LogicalKeyboardKey.escape:
-        updateUserMediaModel();
-        Navigator.pop(context);
+        if (isFullscreen) {
+          fullscreenToggle();
+          break;
+        } else {
+          updateUserMediaModel();
+          Navigator.pop(context);
+        }
         break;
       default:
+        break;
     }
   }
 
@@ -405,7 +421,7 @@ class _ReadingScreenState extends State<ReadingScreen> {
   Widget build(BuildContext context) {
     double totalWidth = MediaQuery.of(context).size.width;
     double totalHeight = MediaQuery.of(context).size.height;
-    double usableHeight = totalHeight - 50;
+    double usableHeight = totalHeight - (isFullscreen ? 0 : barHeight);
 
     return Material(
       color: const Color.fromARGB(255, 34, 33, 34),
@@ -431,29 +447,36 @@ class _ReadingScreenState extends State<ReadingScreen> {
             Column(
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
-                FocusScope(
-                  canRequestFocus: false,
-                  child: MangaOptionsBar(
-                    width: totalWidth,
-                    height: barHeight,
-                    currentPage: currentPage,
-                    totalPages: totalPages,
-                    pageOption: currentPageOption,
-                    currentChapter: widget.currentChapter,
-                    chaptersId: widget.chaptersId,
-                    setNewPageOption: setNewPageOption,
-                    fittingOption: currentFittingOption,
-                    setNewFittingOption: setNewFittingPageOption,
-                    orientationOption: currentOrientationOption,
-                    setNewOrientationOption: setNewOrientationOption,
-                    inverseModeOption: currentInverseModeOption,
-                    setNewInverseModeOption: setNewInverseModeOption,
-                    initPages: initPages,
-                    updateUserMediaModel: updateUserMediaModel,
-                    goBackPage: goBackPage,
-                    goForwardPage: goForwardPage,
+                if (!isFullscreen)
+                  FocusScope(
+                    canRequestFocus: false,
+                    child: MangaOptionsBar(
+                      width: totalWidth,
+                      height: barHeight,
+                      currentPage: currentPage,
+                      totalPages: totalPages,
+                      pageOption: currentPageOption,
+                      currentChapter: widget.currentChapter,
+                      chaptersId: widget.chaptersId,
+                      setNewPageOption: setNewPageOption,
+                      fittingOption: currentFittingOption,
+                      setNewFittingOption: setNewFittingPageOption,
+                      orientationOption: currentOrientationOption,
+                      setNewOrientationOption: setNewOrientationOption,
+                      inverseModeOption: currentInverseModeOption,
+                      setNewInverseModeOption: setNewInverseModeOption,
+                      initPages: initPages,
+                      updateUserMediaModel: updateUserMediaModel,
+                      goBackPage: goBackPage,
+                      goForwardPage: goForwardPage,
+                      isFullscreen: isFullscreen,
+                      toggleFullscreen: () {
+                        setState(() {
+                          isFullscreen = !isFullscreen;
+                        });
+                      },
+                    ),
                   ),
-                ),
                 SizedBox(
                   width: totalWidth,
                   height: usableHeight,
@@ -469,3 +492,4 @@ class _ReadingScreenState extends State<ReadingScreen> {
     );
   }
 }
+

--- a/lib/widgets/manga/manga_options_bar.dart
+++ b/lib/widgets/manga/manga_options_bar.dart
@@ -24,6 +24,8 @@ class MangaOptionsBar extends StatefulWidget {
     required this.currentChapter,
     required this.chaptersId,
     required this.initPages,
+    required this.isFullscreen,
+    required this.toggleFullscreen,
   });
 
   final double width;
@@ -36,6 +38,7 @@ class MangaOptionsBar extends StatefulWidget {
   final int fittingOption;
   final int orientationOption;
   final int inverseModeOption;
+  final bool isFullscreen;
 
   final void Function(int) setNewPageOption;
   final void Function(int) setNewFittingOption;
@@ -46,6 +49,7 @@ class MangaOptionsBar extends StatefulWidget {
   final void Function() updateUserMediaModel;
   final void Function() goForwardPage;
   final void Function() goBackPage;
+  final void Function() toggleFullscreen;
 
   @override
   State<MangaOptionsBar> createState() => _MangaOptionsBarState();
@@ -59,6 +63,7 @@ class _MangaOptionsBarState extends State<MangaOptionsBar> {
   List<List<dynamic>>? pageButtonOptions;
   List<List<dynamic>>? orientationButtonOptions;
   List<List<dynamic>>? inverseButtonOptions;
+  List<List<dynamic>>? fullScreenButtonOptions;
   List<String>? fittingButtonOptions;
   late int currentPageOption;
   late int currentFittingOption;
@@ -66,6 +71,7 @@ class _MangaOptionsBarState extends State<MangaOptionsBar> {
   late int currentInverseOption;
   late int currentChapter;
   late List<String> chaptersId;
+  bool listsInitialized = false;
 
   @override
   void initState() {
@@ -99,6 +105,15 @@ class _MangaOptionsBarState extends State<MangaOptionsBar> {
     }
   }
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!listsInitialized) {
+      initOptionsLists();
+      setState(() => listsInitialized = true);
+    }
+  }
+
   void initOptionsLists() {
     pageButtonOptions = [
       [context.tr("single_page"), Icons.library_books], // 0
@@ -113,7 +128,10 @@ class _MangaOptionsBarState extends State<MangaOptionsBar> {
       [context.tr("light_mode"), Icons.remove_red_eye_outlined],
       [context.tr("dark_mode"), Icons.remove_red_eye],
     ];
-
+    fullScreenButtonOptions = [
+      [context.tr("enter_fullscreen"), Icons.fullscreen],
+      [context.tr("exit_fullscreen"), Icons.fullscreen_exit],
+    ];
     fittingButtonOptions = [
       context.tr("fit_height"),
       context.tr("fit_width"),
@@ -402,7 +420,32 @@ class _MangaOptionsBarState extends State<MangaOptionsBar> {
                           ),
                         ),
                       ],
-                    )
+
+                    ),
+                    const SizedBox(
+                      width: 10,
+                    ),
+                    StyledButton(
+                      onPressed: widget.toggleFullscreen,
+                      child: Row(
+                        children: [
+                          Text(
+                            widget.isFullscreen
+                              ? fullScreenButtonOptions![1][0]
+                              : fullScreenButtonOptions![0][0],
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          const SizedBox(width: 4),
+                          Icon(
+                            widget.isFullscreen
+                              ? fullScreenButtonOptions![1][1]
+                              : fullScreenButtonOptions![0][1],
+                            size: 18,
+                            color: Colors.white,
+                          ),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
                 const Divider(
@@ -416,5 +459,6 @@ class _MangaOptionsBarState extends State<MangaOptionsBar> {
             ),
           )
         : const SizedBox();
+        
   }
 }

--- a/lib/widgets/media/media_details_info_widget.dart
+++ b/lib/widgets/media/media_details_info_widget.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_list_view/smooth_list_view.dart';
 import 'package:unyo/models/models.dart';
@@ -89,6 +90,9 @@ class MediaDetailsInfoWidget extends StatelessWidget {
     String? description = currentAnime != null
         ? currentAnime!.description
         : currentManga!.description;
+    List<String>? genres = currentAnime != null
+        ? currentAnime!.genres
+        : currentManga!.genres;
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.start,
@@ -205,12 +209,30 @@ class MediaDetailsInfoWidget extends StatelessWidget {
               const SizedBox(
                 height: 30,
               ),
+              if (genres != null && genres.isNotEmpty)
+                Transform.translate(
+                  offset: const Offset(0, -14),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Text(
+                      'Genres: ${genres.join(', ')}',
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                ),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: Text(
                   description
                           ?.replaceAll("<br>", "\n")
+                          .replaceAll("</br>", "")
+                          .replaceAll("<BR>", "")
+                          .replaceAll("</BR>", "")
                           .replaceAll("<i>", "")
+                          .replaceAll("</i>", "")
                           .replaceAll("<b>", "")
                           .replaceAll("</b>", "") ??
                       "",


### PR DESCRIPTION
### **Display Genres for Anime and Manga**

* Unified genre rendering in `MediaDetailsInfoWidget` to support both anime and manga.
* Genres are sourced from either `currentAnime` or `currentManga`, depending on the content type.
* The "Genres: ..." section is conditionally displayed only when genre data is available.

---

### **Full-Screen Reading Mode for Manga**

* Implemented full-screen mode for the manga reading page to improve the reading experience.
* Controls:

  * Press **F** to enter full-screen mode.
  * Press **F** or **Escape** to exit full-screen mode.
* This provides a cleaner and more immersive interface for readers.
